### PR TITLE
upgrade ngx-monaco-editor to v2

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -19,7 +19,7 @@
             "assets": [
               {
                 "glob": "**/*",
-                "input": "node_modules/ngx-monaco-editor/assets/monaco",
+                "input": "node_modules/monaco-editor",
                 "output": "/assets/monaco"
               },
               "src/assets",
@@ -119,7 +119,7 @@
             "assets": [
               {
                 "glob": "**/*",
-                "input": "node_modules/ngx-monaco-editor/assets/monaco",
+                "input": "node_modules/monaco-editor",
                 "output": "/assets/monaco"
               },
               "src/assets",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "core-js": "^2.6.12",
         "express": "^4.17.2",
         "hawk": "^7.1.2",
-        "ngx-monaco-editor": "^5.0.0",
+        "ngx-monaco-editor-v2": "^15.0.1",
         "rimraf": "^2.6.3",
         "rxjs": "^6.6.7",
         "rxjs-compat": "^6.6.7",
@@ -9925,6 +9925,13 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10013,13 +10020,18 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/ngx-monaco-editor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-monaco-editor/-/ngx-monaco-editor-5.0.0.tgz",
-      "integrity": "sha512-95MARPggYrpwk0Sf6IisaOw82Y/FQ5084kdX6vGzMLmaNnz4Dg2Uo/WoYTnbV+1299VMwdS0RgtQiZPhKlD/kQ==",
+    "node_modules/ngx-monaco-editor-v2": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-monaco-editor-v2/-/ngx-monaco-editor-v2-15.0.1.tgz",
+      "integrity": "sha512-QDj4XJO7o+XcYqbUrbIWhJdSRUnbAXltShsLveyVug+yw7ThS3DcE+FBuDUnAO67czTWta0paQPsyrH5DUfnkg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
       "peerDependencies": {
-        "@angular/common": ">= 2.0.0",
-        "@angular/core": ">= 2.0.0"
+        "@angular/common": "^15.0.2",
+        "@angular/core": "^15.0.2",
+        "monaco-editor": "^0.34.1"
       }
     },
     "node_modules/nice-napi": {
@@ -21748,6 +21760,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "monaco-editor": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
+      "peer": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -21808,11 +21826,13 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "ngx-monaco-editor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-monaco-editor/-/ngx-monaco-editor-5.0.0.tgz",
-      "integrity": "sha512-95MARPggYrpwk0Sf6IisaOw82Y/FQ5084kdX6vGzMLmaNnz4Dg2Uo/WoYTnbV+1299VMwdS0RgtQiZPhKlD/kQ==",
-      "requires": {}
+    "ngx-monaco-editor-v2": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-monaco-editor-v2/-/ngx-monaco-editor-v2-15.0.1.tgz",
+      "integrity": "sha512-QDj4XJO7o+XcYqbUrbIWhJdSRUnbAXltShsLveyVug+yw7ThS3DcE+FBuDUnAO67czTWta0paQPsyrH5DUfnkg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
     },
     "nice-napi": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "core-js": "^2.6.12",
     "express": "^4.17.2",
     "hawk": "^7.1.2",
-    "ngx-monaco-editor": "^5.0.0",
+    "ngx-monaco-editor-v2": "^15.0.1",
     "rimraf": "^2.6.3",
     "rxjs": "^6.6.7",
     "rxjs-compat": "^6.6.7",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { FooterComponent } from './footer/footer.component';
 import { CompareEditorComponent } from './compare-editor/compare-editor.component';
 
 import { FormsModule } from '@angular/forms';
-import { MonacoEditorModule } from 'ngx-monaco-editor';
+import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 
 // routes
 import { appRoutes } from './app.route';

--- a/src/app/compare-editor/compare-editor.component.ts
+++ b/src/app/compare-editor/compare-editor.component.ts
@@ -5,7 +5,7 @@ import {
   Output,
   OnInit
 } from '@angular/core';
-import { DiffEditorModel } from 'ngx-monaco-editor';
+import { DiffEditorModel } from 'ngx-monaco-editor-v2';
 
 @Component({
   selector: 'widget-compare-editor',


### PR DESCRIPTION
Upgrade `ngx-monaco-editor` to `ngx-monaco-editor-v2`, see https://www.npmjs.com/package/ngx-monaco-editor-v2.

The major version of `ngx-monaco-editor-v2`(eg. 15.0.1) should be same with angular version(eg. 15.2.10)